### PR TITLE
Move project

### DIFF
--- a/components/item-delegate.go
+++ b/components/item-delegate.go
@@ -6,9 +6,25 @@ import (
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
-type itemDelegate struct{}
+type itemDelegate struct {
+	movingInitialIndex int
+}
+
+var (
+	itemStyle = lipgloss.NewStyle().
+			PaddingLeft(4)
+
+	selectedItemStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#6C91BF")).
+				PaddingLeft(2)
+
+	selectedItemForMovingStyle = lipgloss.NewStyle().
+					Foreground(lipgloss.Color("#4d4d4d")).
+					PaddingLeft(2)
+)
 
 func (d itemDelegate) Height() int                               { return 1 }
 func (d itemDelegate) Spacing() int                              { return 0 }
@@ -20,6 +36,10 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 	if index == m.Index() {
 		fn = func(s string) string {
 			return selectedItemStyle.Render("> " + s)
+		}
+	} else if index == d.movingInitialIndex {
+		fn = func(s string) string {
+			return selectedItemForMovingStyle.Render("* " + s)
 		}
 	}
 

--- a/components/item-delegate.go
+++ b/components/item-delegate.go
@@ -10,7 +10,7 @@ import (
 )
 
 type itemDelegate struct {
-	movingInitialIndex int
+	movingModeInitialIndex int
 }
 
 var (
@@ -37,7 +37,7 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 		fn = func(s string) string {
 			return selectedItemStyle.Render("> " + s)
 		}
-	} else if index == d.movingInitialIndex {
+	} else if index == d.movingModeInitialIndex {
 		fn = func(s string) string {
 			return selectedItemForMovingStyle.Render("* " + s)
 		}

--- a/components/list-selector.go
+++ b/components/list-selector.go
@@ -58,18 +58,18 @@ var (
 )
 
 type listSelectorModel struct {
-	list               list.Model
-	items              []list.Item
-	choice             *models.Project
-	projectForm        *projectFormModel
-	fatalError         error
-	movingModeActive   bool
-	movingInitialIndex int
-	quitting           bool
+	list                   list.Model
+	items                  []list.Item
+	choice                 *models.Project
+	projectForm            *projectFormModel
+	fatalError             error
+	movingModeActive       bool
+	movingModeInitialIndex int
+	quitting               bool
 }
 
 func NewListSelector() tea.Model {
-	l := list.New([]list.Item{}, itemDelegate{movingInitialIndex: -1}, listWidth, listHeight)
+	l := list.New([]list.Item{}, itemDelegate{movingModeInitialIndex: -1}, listWidth, listHeight)
 
 	l.Title = initialTitle
 	l.SetShowStatusBar(false)
@@ -205,7 +205,7 @@ func handleKeyMsg(m *listSelectorModel, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 			return m, tea.Quit
 		} else {
-			projects, err := models.SwapProjectIndex(m.movingInitialIndex, m.list.Index())
+			projects, err := models.SwapProjectIndex(m.movingModeInitialIndex, m.list.Index())
 			if err != nil {
 				m.Update(projectUpdateErrorMsg(err))
 				return m, nil
@@ -268,8 +268,8 @@ func handleKeyMsg(m *listSelectorModel, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case "m":
-		m.movingInitialIndex = m.list.Index()
-		m.list.SetDelegate(itemDelegate{movingInitialIndex: m.movingInitialIndex})
+		m.movingModeInitialIndex = m.list.Index()
+		m.list.SetDelegate(itemDelegate{movingModeInitialIndex: m.movingModeInitialIndex})
 		m.movingModeActive = true
 
 		m.list.Styles.Title = movingTitleStyle
@@ -319,9 +319,9 @@ func resetListTitle(m *listSelectorModel) {
 
 // disableMovingMode resets required value to disable the moving mode.
 func disableMovingMode(m *listSelectorModel) {
-	m.movingInitialIndex = -1
+	m.movingModeInitialIndex = -1
 	m.movingModeActive = false
-	m.list.SetDelegate(itemDelegate{movingInitialIndex: -1})
+	m.list.SetDelegate(itemDelegate{movingModeInitialIndex: -1})
 	resetListTitle(m)
 }
 

--- a/models/project.go
+++ b/models/project.go
@@ -136,3 +136,30 @@ func DeleteProject(index int, project Project) ([]Project, error) {
 
 	return projects, nil
 }
+
+// SwapProjectIndex fetches the projects from the disk, swap both projects by index then saves the updated list.
+// Returns the updated list if no error occurs. Forwards the error otherwise.
+func SwapProjectIndex(initialIndex int, targetIndex int) ([]Project, error) {
+	projects, err := GetProjects()
+	if err != nil {
+		return nil, err
+	}
+
+	if initialIndex < 0 || initialIndex >= len(projects) {
+		return nil, errors.New("initial index out of bound")
+	} else if targetIndex < 0 || targetIndex >= len(projects) {
+		return nil, errors.New("target index out of bound")
+	}
+
+	if initialIndex == targetIndex {
+		return projects, nil
+	}
+
+	p := projects[initialIndex]
+	projects[initialIndex] = projects[targetIndex]
+	projects[targetIndex] = p
+
+	err = fileutils.SaveToFile(projects, fileutils.GetFullProjectsFilePath())
+
+	return projects, nil
+}


### PR DESCRIPTION
# 📖 Description
Add a new keybind (`m`) to move a selected project with another one. Basically given `i`, `j` as valid indices, the projects will be updated to `projects[i] = projects[j]` and `projects[j] = projects[i]`. 

# 📷 Screenshots
<img src="https://user-images.githubusercontent.com/16008095/186264475-10e59ac4-0e74-4f05-a1f9-e4e8525b8723.png" width="300px">

_* `jasper` is selected for a swap here_